### PR TITLE
Feature: Iterate context items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/libsabl/context-net/graph/badge.svg?token=MQyjVJuA0H)](https://codecov.io/gh/libsabl/context-net)
+
 # Sabl.Context
 
 Implementation of Sabl context pattern for dotnet.

--- a/src/Sabl.Context/Context.cs
+++ b/src/Sabl.Context/Context.cs
@@ -5,10 +5,10 @@ namespace Sabl;
 
 /// <summary>
 /// A base implementation of <see cref="IContext"/> that 
-/// provides a name and an inner context. The inner context is neither
+/// provides a name and an parent context. The parent context is neither
 /// required nor guaranteed to be non-null
 /// </summary>
-public abstract class Context : IContext
+public abstract class Context : IContext, IChildContext
 {
     private readonly CancellationToken _parentToken;
 

--- a/src/Sabl.Context/ContextKey.cs
+++ b/src/Sabl.Context/ContextKey.cs
@@ -1,21 +1,33 @@
 ﻿// Copyright 2023 Joshua Honig. All rights reserved.
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Sabl;
 
+/// <summary>A reference-equality key with both a string label and a target type</summary>
+/// <remarks>
+/// ContextKeys are always compared with reference equality. Two key instances
+/// with the same label and value type will not be considered equal.
+/// </remarks>
 public abstract class ContextKey
 {
-    public readonly string Label;
+    /// <summary>A descriptive label for the key</summary>
+    public string Label { get; }
+
     private readonly int _hash;
 
-    public ContextKey(string label)
+    internal ContextKey(string label)
     {
-        Label = label;
+        ArgumentNullException.ThrowIfNull(label, nameof(label));
+        this.Label = label;
         _hash = label.GetHashCode();
     }
 
+    /// <summary>The runtime type of values to be associated with this key</summary>
     internal abstract Type ValueType { get; }
 
+    /// <summary>Indicates whether <see cref="ValueType"/> is a <see cref="Nullable{T}"/></summary>
     internal abstract bool Nullable { get; }
 
     /// <inheritdoc />
@@ -25,22 +37,44 @@ public abstract class ContextKey
     public override bool Equals(object? obj) => object.ReferenceEquals(this, obj);
 
     /// <inheritdoc />
-    public override string ToString() => "Key(" + Label + ")";
+    public override string ToString() => "Key(" + this.Label + ")";
 
     /// <inheritdoc />
     public static bool operator ==(ContextKey a, ContextKey b) => object.ReferenceEquals(a, b);
 
     /// <inheritdoc />
     public static bool operator !=(ContextKey a, ContextKey b) => !object.ReferenceEquals(a, b);
+
+    /// <summary>Check if <paramref name="value"/> can be associated with <paramref name="key"/>.
+    /// If not, assigns an appropriate exception to <see langword="out"/> <paramref name="ex"/></summary>
+    public static bool IsValueAllowed(ContextKey key, object? value, [NotNullWhen(false)] out Exception? ex)
+    {
+        if (value == null) {
+            if (!key.Nullable) {
+                ex = new ArgumentNullException(nameof(value), $"Cannot use null value for value of non-nullable type {key.ValueType}");
+                return false;
+            }
+        } else {
+            if (!value.GetType().IsAssignableTo(key.ValueType)) {
+                ex = new InvalidCastException($"Provided value of type {value.GetType()} cannot be assigned to type {key.ValueType} associated with key {key.Label}");
+                return false;
+            }
+        }
+        ex = null;
+        return true;
+    }
 }
 
+/// <summary>A <see cref="ContextKey"/> associated with a specific value type <typeparamref name="T"/></summary>
 public sealed class ContextKey<T> : ContextKey
 {
     private readonly Type _type;
     private readonly bool _nullable;
 
-    public ContextKey() : this(typeof(T).Name) { }
+    /// <summary>Create a new context key with the default label of typeof(<typeparamref name="T"/>.Name</summary>
+    public ContextKey() : this(TypeName(typeof(T))) { }
 
+    /// <summary>Create a new context key with the provided label</summary>
     public ContextKey(string label) : base(label)
     {
         _type = typeof(T);
@@ -58,4 +92,15 @@ public sealed class ContextKey<T> : ContextKey
     internal override Type ValueType => _type;
 
     internal override bool Nullable => _nullable;
+
+    private static string TypeName(Type type)
+    {
+        if (type.IsGenericType) {
+            var tdef = type.GetGenericTypeDefinition();
+            if (tdef == typeof(Nullable<>)) {
+                return "Nullable<" + type.GetGenericArguments()[0].Name + ">";
+            }
+        }
+        return type.Name;
+    }
 }

--- a/src/Sabl.Context/IContext.cs
+++ b/src/Sabl.Context/IContext.cs
@@ -7,7 +7,7 @@ namespace Sabl;
 public interface IContext
 {
     /// <summary>Retrieve a named value by its key</summary>
-    /// <remarks>Value should simply return null if the key is not defined</remarks>
+    /// <remarks><see cref="Value" /> should simply return null if the key is not defined</remarks>
     object? Value(object key);
 
     /// <summary>The cancellation token for the context</summary>
@@ -26,4 +26,15 @@ public interface ICancelContext : IContext, IDisposable
     /// Cancel the context and all descendant contexts
     /// </summary>
     void Cancel();
+}
+
+/// <summary>
+/// A <see cref="IContext"/> which has a parent context
+/// </summary>
+public interface IChildContext : IContext
+{
+    /// <summary>
+    /// The parent context of the current context
+    /// </summary>
+    IContext? Parent { get; }
 }

--- a/src/Sabl.Context/ValueContext.cs
+++ b/src/Sabl.Context/ValueContext.cs
@@ -12,6 +12,10 @@ internal class ValueContext : Context
         this.value = value;
     }
 
+    internal object Key => key;
+
+    internal object? OwnValue => value;
+
     private readonly object key;
     private readonly object? value;
 

--- a/src/Sabl.Context/ValueContextExtensions.cs
+++ b/src/Sabl.Context/ValueContextExtensions.cs
@@ -21,31 +21,11 @@ public static class ValueContextExtensions
         return new ValueContext(context, key, value);
     }
 
-    /// <summary>Get a definitely typed class instance from the context, returning null if the item is not defined</summary> 
-    public static T? Value<T>(this IContext context, ContextKey<T> key) where T : class
+    /// <summary>Get a definitely typed value from the context, returning default(T) if the item is not defined</summary> 
+    public static T? Get<T>(this IContext context, ContextKey<T> key)  
     {
         var raw = context.Value(key);
-        if (raw is null) return null;
-        if (raw is T value) return value;
-        throw new InvalidCastException($"Invalid value associated with key {key.Label}");
-    }
-
-    /// <summary>Get a definitely typed struct value from the context, returning null if the item is not defined</summary> 
-    /// <remarks>This overload supports keys where the the key type is a <see cref="Nullable{T}"/></remarks>
-    public static T? Try<T>(this IContext context, ContextKey<T?> key) where T : struct
-    {
-        var raw = context.Value((object)key);
-        if (raw is null) return null;
-        if (raw is T value) return value;
-        throw new InvalidCastException($"Invalid value associated with key {key.Label}");
-    }
-
-    /// <summary>Get a definitely typed struct value from the context, returning null if the item is not defined</summary> 
-    /// <remarks>This overload supports keys where the the key type is a non-nullable value type</remarks>
-    public static T? Try<T>(this IContext context, ContextKey<T> key) where T : struct
-    {
-        var raw = context.Value((object)key);
-        if (raw is null) return null;
+        if (raw is null) return default;
         if (raw is T value) return value;
         throw new InvalidCastException($"Invalid value associated with key {key.Label}");
     }
@@ -68,7 +48,7 @@ public static class ValueContextExtensions
     /// the iteration.
     /// </remarks>
     public static IEnumerable<KeyValuePair<object, object?>> AllValues(this IContext context, bool distinct = false)
-        => distinct ? AllDistinctValues(context) : AllValuesNonDistinct(context);
+        => distinct ? AllValuesDistinct(context) : AllValuesNonDistinct(context);
 
     private static IEnumerable<KeyValuePair<object, object?>> AllValuesNonDistinct(IContext context)
     {
@@ -81,7 +61,7 @@ public static class ValueContextExtensions
         }
     }
 
-    private static IEnumerable<KeyValuePair<object, object?>> AllDistinctValues(IContext context)
+    private static IEnumerable<KeyValuePair<object, object?>> AllValuesDistinct(IContext context)
     {
         var cctx = context as IChildContext;
         if (cctx == null)

--- a/src/Sabl.Context/ValueContextExtensions.cs
+++ b/src/Sabl.Context/ValueContextExtensions.cs
@@ -9,29 +9,20 @@ namespace Sabl;
 public static class ValueContextExtensions
 {
     /// <summary>Create a child context with the provided value set</summary>
+    /// <remarks>
+    /// If <paramref name="key"/> is a <see cref="ContextKey"/>, the
+    /// runtime type of <paramref name="value"/> will be enforced
+    /// </remarks>
     public static IContext WithValue(this IContext context, object key, object? value)
     {
-        if (key is ContextKey ckey) {
-            if (value == null) {
-                if (!ckey.Nullable) {
-                    throw new ArgumentNullException(nameof(value), $"Cannot use null value for value of non-nullable type {ckey.ValueType}");
-                }
-            } else {
-                if (!value.GetType().IsAssignableTo(ckey.ValueType)) {
-                    throw new InvalidCastException($"Provided value cannot be assigned to type {ckey.ValueType} associated with key {ckey.Label}");
-                }
-            }
+        if (key is ContextKey ckey && !ContextKey.IsValueAllowed(ckey, value, out var ex)) {
+            throw ex;
         }
-
         return new ValueContext(context, key, value);
     }
 
-    /// <summary>Create a child context with the provided definitely type value set</summary>
-    public static IContext WithValue<T>(this IContext context, ContextKey<T> key, T value)
-        => new ValueContext(context, key, value);
-
     /// <summary>Get a definitely typed class instance from the context, returning null if the item is not defined</summary> 
-    public static T? Get<T>(this IContext context, ContextKey<T> key) where T : class?
+    public static T? Value<T>(this IContext context, ContextKey<T> key) where T : class
     {
         var raw = context.Value(key);
         if (raw is null) return null;
@@ -40,9 +31,20 @@ public static class ValueContextExtensions
     }
 
     /// <summary>Get a definitely typed struct value from the context, returning null if the item is not defined</summary> 
-    public static T? GetValue<T>(this IContext context, ContextKey<T> key) where T : struct
+    /// <remarks>This overload supports keys where the the key type is a <see cref="Nullable{T}"/></remarks>
+    public static T? Try<T>(this IContext context, ContextKey<T?> key) where T : struct
     {
-        var raw = context.Value(key);
+        var raw = context.Value((object)key);
+        if (raw is null) return null;
+        if (raw is T value) return value;
+        throw new InvalidCastException($"Invalid value associated with key {key.Label}");
+    }
+
+    /// <summary>Get a definitely typed struct value from the context, returning null if the item is not defined</summary> 
+    /// <remarks>This overload supports keys where the the key type is a non-nullable value type</remarks>
+    public static T? Try<T>(this IContext context, ContextKey<T> key) where T : struct
+    {
+        var raw = context.Value((object)key);
         if (raw is null) return null;
         if (raw is T value) return value;
         throw new InvalidCastException($"Invalid value associated with key {key.Label}");
@@ -51,9 +53,46 @@ public static class ValueContextExtensions
     /// <summary>Get a definitely typed value from the context, throwing an exception if the item is null or undefined</summary> 
     public static T Require<T>(this IContext context, ContextKey<T> key)
     {
-        var raw = context.Value(key) ?? throw new KeyNotFoundException($"Context item for key {key.Label} was null or undefined");
+        var raw = context.Value((object)key) ?? throw new KeyNotFoundException($"Context item for key {key.Label} was null or undefined");
         if (raw is T value) return value;
-        throw new InvalidCastException($"Invalid value associated with key {key.Label}");
+        throw new InvalidCastException($"Invalid value of type {raw.GetType().FullName} associated with key {key.Label} for type {key.ValueType.FullName}");
     }
 
+    /// <summary>
+    /// Iterate through all key-value pairs reachable from the context
+    /// </summary>
+    /// <param name="context">The starting context</param>
+    /// <param name="distinct">Whether to return only one key-value pair per unique key value</param>
+    /// <remarks>
+    /// Any intermediate contexts that to do not implement <see cref="IChildContext"/> will terminate
+    /// the iteration.
+    /// </remarks>
+    public static IEnumerable<KeyValuePair<object, object?>> AllValues(this IContext context, bool distinct = false)
+        => distinct ? AllDistinctValues(context) : AllValuesNonDistinct(context);
+
+    private static IEnumerable<KeyValuePair<object, object?>> AllValuesNonDistinct(IContext context)
+    {
+        var cctx = context as IChildContext;
+        while (cctx != null) {
+            if (cctx is ValueContext vctx) {
+                yield return new KeyValuePair<object, object?>(vctx.Key, vctx.OwnValue);
+            }
+            cctx = cctx.Parent as IChildContext;
+        }
+    }
+
+    private static IEnumerable<KeyValuePair<object, object?>> AllDistinctValues(IContext context)
+    {
+        var cctx = context as IChildContext;
+        if (cctx == null)
+            yield break;
+
+        var keys = new HashSet<object>();
+        while (cctx != null) {
+            if (cctx is ValueContext vctx && keys.Add(vctx.Key)) {
+                yield return new KeyValuePair<object, object?>(vctx.Key, vctx.OwnValue);
+            }
+            cctx = cctx.Parent as IChildContext;
+        }
+    }
 }

--- a/tests/Sabl.Context.Tests/CancelContext.Tests.cs
+++ b/tests/Sabl.Context.Tests/CancelContext.Tests.cs
@@ -8,7 +8,7 @@ public class Ctor
     [Fact]
     public void CalledCancel()
     {
-        var cctx = new CancelContext(null);
+        using var cctx = new CancelContext(null);
         Assert.Equal("Cancel", cctx.Name);
         cctx.TokenSource.Dispose();
     }
@@ -16,11 +16,10 @@ public class Ctor
 
 public class CancelDispose
 {
-
     [Fact]
     public void DisposeDoesNotCancel()
     {
-        var cctx = new CancelContext(null);
+        using var cctx = new CancelContext(null);
         var token = cctx.CancellationToken;
 
         Assert.False(token.IsCancellationRequested);
@@ -33,7 +32,7 @@ public class CancelDispose
     [Fact]
     public void CannotCancelAfterDispose()
     {
-        var cctx = new CancelContext(null);
+        using var cctx = new CancelContext(null);
         var token = cctx.CancellationToken;
 
         Assert.False(token.IsCancellationRequested);
@@ -48,7 +47,7 @@ public class CancelDispose
     [Fact]
     public void CanCancelManyTimes()
     {
-        var cctx = new CancelContext(null);
+        using var cctx = new CancelContext(null);
         var token = cctx.CancellationToken;
 
         Assert.False(token.IsCancellationRequested);
@@ -70,7 +69,7 @@ public class CancelDispose
     [Fact]
     public void CanDisposeManyTimes()
     {
-        var cctx = new CancelContext(null);
+        using var cctx = new CancelContext(null);
 
         cctx.Dispose();
 
@@ -80,7 +79,6 @@ public class CancelDispose
         cctx.Dispose();
     }
 }
-
 
 public class Tree
 {
@@ -102,8 +100,8 @@ public class Tree
     [Fact]
     public void DisposeAutomaticallyUnregisters()
     {
-        var ctxParent = new CancelContext(null);
-        var ctxChild = ctxParent.WithValue("One", 1).WithValue("Two", 2).WithCancel();
+        using var ctxParent = new CancelContext(null);
+        using var ctxChild = ctxParent.WithValue("One", 1).WithValue("Two", 2).WithCancel();
 
         var regCnt = ctxParent.TokenSource.GetRegistrationCount();
         Assert.Equal(1, regCnt);
@@ -117,8 +115,8 @@ public class Tree
     [Fact]
     public void CancelAutomaticallyUnregisters()
     {
-        var ctxParent = new CancelContext(null);
-        var ctxChild = ctxParent.WithValue("One", 1).WithValue("Two", 2).WithCancel();
+        using var ctxParent = new CancelContext(null);
+        using var ctxChild = ctxParent.WithValue("One", 1).WithValue("Two", 2).WithCancel();
 
         var regCnt = ctxParent.TokenSource.GetRegistrationCount();
         Assert.Equal(1, regCnt);
@@ -143,5 +141,4 @@ public class Tree
         Assert.True(ctxChild.CancellationToken.IsCancellationRequested);
         Assert.False(ctxParent.CancellationToken.IsCancellationRequested);
     }
-
 }

--- a/tests/Sabl.Context.Tests/ContextKey.Tests.cs
+++ b/tests/Sabl.Context.Tests/ContextKey.Tests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2023 Joshua Honig. All rights reserved.
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 
+using System.Collections.Generic;
 using System.Text;
 
 namespace Sabl.ContextKeyClass;
@@ -21,6 +22,20 @@ public class Ctor
     {
         var key = new ContextKey<string>();
         Assert.Equal("String", key.Label);
+    }
+
+    [Fact]
+    public void DefaultsLabelToTypeName_Nullable()
+    {
+        var key = new ContextKey<int?>();
+        Assert.Equal("Nullable<Int32>", key.Label);
+    }
+
+    [Fact]
+    public void DefaultsLabelToTypeName_Generic()
+    {
+        var key = new ContextKey<Dictionary<string, int>>();
+        Assert.Equal("Dictionary`2", key.Label);
     }
 
     [Fact]

--- a/tests/Sabl.Context.Tests/ValueContextExtensions.Tests.cs
+++ b/tests/Sabl.Context.Tests/ValueContextExtensions.Tests.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Sabl.ValueContextExtensionsClass;
@@ -83,25 +84,12 @@ public class WithValue
         var ctx = Context.Background;
 
         var ex = Assert.Throws<InvalidCastException>(() => ctx.WithValue((object)key, DateTime.Now));
-        var expectedMessage = "Provided value cannot be assigned to type System.Int32 associated with key Int32";
+        var expectedMessage = "Provided value of type System.DateTime cannot be assigned to type System.Int32 associated with key Int32";
         Assert.Equal(expectedMessage, ex.Message);
     }
 }
 
-public class WithValueOfT
-{
-    [Fact]
-    public void AssignsValue()
-    {
-        ContextKey<int> key = new();
-        var ctx = Context.Background;
-        var vctx = ctx.WithValue(key, 42);
-        var v = vctx.Value(key);
-        Assert.Equal(42, v);
-    }
-}
-
-public class GetOfT
+public class ValueOfT
 {
     [Fact]
     public void ReturnsValue()
@@ -109,7 +97,7 @@ public class GetOfT
         ContextKey<Encoding> key = new();
         var ctx = Context.Background;
         var vctx = ctx.WithValue(key, Encoding.UTF8);
-        var v = vctx.Get(key);
+        var v = ValueContextExtensions.Value(vctx, key);
         Assert.Same(Encoding.UTF8, v);
     }
 
@@ -118,7 +106,7 @@ public class GetOfT
     {
         ContextKey<Encoding> key = new();
         var ctx = Context.Background;
-        var v = ctx.Get(key);
+        var v = ValueContextExtensions.Value(ctx, key);
         Assert.Null(v);
     }
 
@@ -127,13 +115,43 @@ public class GetOfT
     {
         ContextKey<Encoding> key = new();
         var ctx = new ValueContext(Context.Background, key, "boom");
-        var ex = Assert.Throws<InvalidCastException>(() => ctx.Get(key));
+        var ex = Assert.Throws<InvalidCastException>(() => ValueContextExtensions.Value(ctx, key));
         Assert.Equal("Invalid value associated with key Encoding", ex.Message);
     }
 }
 
+public class TryOfNullableT
+{
+    [Fact]
+    public void ReturnsValue()
+    {
+        ContextKey<int?> key = new();
+        var ctx = Context.Background;
+        var vctx = ctx.WithValue(key, 22);
+        var v = vctx.Try(key);
+        Assert.Equal(22, v);
+    }
 
-public class GetValueOfT
+    [Fact]
+    public void ReturnsNull()
+    {
+        ContextKey<int?> key = new();
+        var ctx = Context.Background;
+        var v = ctx.Try(key);
+        Assert.Null(v);
+    }
+
+    [Fact]
+    public void ThrowsInvalidCast()
+    {
+        ContextKey<int?> key = new();
+        var ctx = (IContext)new ValueContext(Context.Background, key, "boom");
+        var ex = Assert.Throws<InvalidCastException>(() => ctx.Try(key));
+        Assert.Equal("Invalid value associated with key Nullable<Int32>", ex.Message);
+    }
+}
+
+public class TryOfT
 {
     [Fact]
     public void ReturnsValue()
@@ -141,7 +159,7 @@ public class GetValueOfT
         ContextKey<int> key = new();
         var ctx = Context.Background;
         var vctx = ctx.WithValue(key, 22);
-        var v = vctx.GetValue(key);
+        var v = vctx.Try(key);
         Assert.Equal(22, v);
     }
 
@@ -150,7 +168,7 @@ public class GetValueOfT
     {
         ContextKey<int> key = new();
         var ctx = Context.Background;
-        var v = ctx.GetValue(key);
+        var v = ctx.Try(key);
         Assert.Null(v);
     }
 
@@ -158,8 +176,8 @@ public class GetValueOfT
     public void ThrowsInvalidCast()
     {
         ContextKey<int> key = new();
-        var ctx = new ValueContext(Context.Background, key, "boom");
-        var ex = Assert.Throws<InvalidCastException>(() => ctx.GetValue(key));
+        var ctx = (IContext)new ValueContext(Context.Background, key, "boom");
+        var ex = Assert.Throws<InvalidCastException>(() => ctx.Try(key));
         Assert.Equal("Invalid value associated with key Int32", ex.Message);
     }
 }
@@ -211,6 +229,79 @@ public class RequireOfT
         ContextKey<Encoding> key = new();
         var ctx = new ValueContext(Context.Background, key, "boom");
         var ex = Assert.Throws<InvalidCastException>(() => ctx.Require(key));
-        Assert.Equal("Invalid value associated with key Encoding", ex.Message);
+        Assert.Equal("Invalid value of type System.String associated with key Encoding for type System.Text.Encoding", ex.Message);
+    }
+}
+
+public class AllValues
+{
+    private static readonly ContextKey<string> strKey1 = new("item 1");
+    private static readonly ContextKey<string> strKey2 = new("item 2");
+    private static readonly ContextKey<int> numKey = new("number");
+
+    private static readonly IContext ctx = Context.Background
+        .WithValue(strKey1, "Hello")
+        .WithValue(strKey2, "Hi")
+        .WithCancel()
+        .WithValue(numKey, 22)
+        .WithValue(strKey2, "Another value");
+
+    [Fact]
+    public void ReturnsAllKeyValuePairs()
+    {
+
+        var pairs = ctx.AllValues().ToList();
+        var expected = new List<KeyValuePair<object, object?>> {
+            new(strKey2, "Another value"),
+            new(numKey, 22),
+            new(strKey2, "Hi"),
+            new(strKey1, "Hello"),
+        };
+
+        Assert.Equal(expected, pairs);
+    }
+
+    [Fact]
+    public void ReturnsDistinctKeyValuePairs()
+    {
+        var pairs = ctx.AllValues(true).ToList();
+        var expected = new List<KeyValuePair<object, object?>> {
+            new(strKey2, "Another value"),
+            new(numKey, 22),
+            new(strKey1, "Hello"),
+        };
+
+        Assert.Equal(expected, pairs);
+    }
+
+    private class SillyContext : IContext
+    {
+        public IContext? MyParent { get; }
+
+        public SillyContext(IContext? myParent)
+        {
+            this.MyParent = myParent;
+        }
+
+        public CancellationToken CancellationToken
+            => this.MyParent?.CancellationToken ?? CancellationToken.None;
+
+        public object? Value(object key)
+            => this.MyParent?.Value(key);
+    }
+
+    [Fact]
+    public void ReturnsEmptyForNonChildContext()
+    {
+        var sillyCtx = new SillyContext(ctx);
+
+        // Yes, it implements .Value and will return items by key
+        Assert.Equal("Hello", sillyCtx.Value(strKey1));
+        Assert.Equal("Another value", sillyCtx.Value(strKey2));
+        Assert.Equal(22, sillyCtx.Value(numKey));
+
+        // But because it does not implement IChildContext, AllValues returns empty
+        var pairs = sillyCtx.AllValues(true);
+        Assert.Empty(pairs);
     }
 }

--- a/tests/Sabl.Context.Tests/ValueContextExtensions.Tests.cs
+++ b/tests/Sabl.Context.Tests/ValueContextExtensions.Tests.cs
@@ -89,7 +89,7 @@ public class WithValue
     }
 }
 
-public class ValueOfT
+public class GetOfT
 {
     [Fact]
     public void ReturnsValue()
@@ -97,7 +97,7 @@ public class ValueOfT
         ContextKey<Encoding> key = new();
         var ctx = Context.Background;
         var vctx = ctx.WithValue(key, Encoding.UTF8);
-        var v = ValueContextExtensions.Value(vctx, key);
+        Encoding? v = vctx.Get(key);
         Assert.Same(Encoding.UTF8, v);
     }
 
@@ -106,7 +106,7 @@ public class ValueOfT
     {
         ContextKey<Encoding> key = new();
         var ctx = Context.Background;
-        var v = ValueContextExtensions.Value(ctx, key);
+        Encoding? v = ctx.Get(key);
         Assert.Null(v);
     }
 
@@ -115,12 +115,12 @@ public class ValueOfT
     {
         ContextKey<Encoding> key = new();
         var ctx = new ValueContext(Context.Background, key, "boom");
-        var ex = Assert.Throws<InvalidCastException>(() => ValueContextExtensions.Value(ctx, key));
+        var ex = Assert.Throws<InvalidCastException>(() => ctx.Get(key));
         Assert.Equal("Invalid value associated with key Encoding", ex.Message);
     }
 }
 
-public class TryOfNullableT
+public class ValueOfNullableT
 {
     [Fact]
     public void ReturnsValue()
@@ -128,7 +128,7 @@ public class TryOfNullableT
         ContextKey<int?> key = new();
         var ctx = Context.Background;
         var vctx = ctx.WithValue(key, 22);
-        var v = vctx.Try(key);
+        int? v = vctx.Get(key);
         Assert.Equal(22, v);
     }
 
@@ -137,7 +137,7 @@ public class TryOfNullableT
     {
         ContextKey<int?> key = new();
         var ctx = Context.Background;
-        var v = ctx.Try(key);
+        int? v = ctx.Get(key);
         Assert.Null(v);
     }
 
@@ -146,7 +146,7 @@ public class TryOfNullableT
     {
         ContextKey<int?> key = new();
         var ctx = (IContext)new ValueContext(Context.Background, key, "boom");
-        var ex = Assert.Throws<InvalidCastException>(() => ctx.Try(key));
+        var ex = Assert.Throws<InvalidCastException>(() => ctx.Get(key));
         Assert.Equal("Invalid value associated with key Nullable<Int32>", ex.Message);
     }
 }
@@ -159,7 +159,7 @@ public class TryOfT
         ContextKey<int> key = new();
         var ctx = Context.Background;
         var vctx = ctx.WithValue(key, 22);
-        var v = vctx.Try(key);
+        int v = vctx.Get(key);
         Assert.Equal(22, v);
     }
 
@@ -168,8 +168,8 @@ public class TryOfT
     {
         ContextKey<int> key = new();
         var ctx = Context.Background;
-        var v = ctx.Try(key);
-        Assert.Null(v);
+        int v = ctx.Get(key);
+        Assert.Equal(0, v);
     }
 
     [Fact]
@@ -177,7 +177,7 @@ public class TryOfT
     {
         ContextKey<int> key = new();
         var ctx = (IContext)new ValueContext(Context.Background, key, "boom");
-        var ex = Assert.Throws<InvalidCastException>(() => ctx.Try(key));
+        var ex = Assert.Throws<InvalidCastException>(() => ctx.Get(key));
         Assert.Equal("Invalid value associated with key Int32", ex.Message);
     }
 }


### PR DESCRIPTION
- Adds feature to allow iterating over all key-value pairs in a context.
- Factors out value type validation to `ContextKey.IsValueAllowed`
- Eliminates `ValueContextExtensions.GetValue` in favor of just returning `default(T)` from `ValueContextExtensions.Get`